### PR TITLE
Inject io dep. when not loading via require

### DIFF
--- a/sails.io.backbone.js
+++ b/sails.io.backbone.js
@@ -18,13 +18,13 @@
 			factory(root, Backbone, io);
 		});
 	} else if(typeof exports !== 'undefined') {
-		factory(root, require('backbone'));
+		factory(root, require('backbone'), io);
 	} else {
-		factory(root, root.Backbone);
+		factory(root, root.Backbone, io);
 	}
 }(this, function(root, Backbone, io) {
-	io.socket.on('message', function cometMessageReceived(message) {
-        Backbone.trigger('comet', message);
+    io.socket.on('message', function cometMessageReceived(message) {
+	Backbone.trigger('comet', message);
     });
 
 


### PR DESCRIPTION
Inject the io dependency when using webpack/browserify, or when the lib is included via `<script>`.
We assume `<script src="dependencies/sails.io.js/dist/sails.io.js"></script>` has already been done.
