### PR TITLE
Correctly attach data to HTTP query params

### DIFF
--- a/sails.io.backbone.js
+++ b/sails.io.backbone.js
@@ -116,7 +116,7 @@
         }
 
         if (_.isObject(options.data)) {
-            _(params).extend(options.data);
+            _.extend(params, options.data);
         }
 
 


### PR DESCRIPTION
Somehow using `_` in a functional way did not correctly extend the `params` object with `options.data`.
Now I ca see the `data` object actually been sent to the server when doing `collection.fetch({ data: {...} })`.
