### PR TITLE
Pass headers options to request

### DIFF
--- a/sails.io.backbone.js
+++ b/sails.io.backbone.js
@@ -136,6 +136,11 @@
                 verb = method;
         }
 
+        // Build request options. By default add and `headers` property
+        var opts = {
+          headers: options.headers || {}
+        };
+
         var promise = Backbone.sails.request(url, verb, params);
 
         promise.done(options.success    || function () {});
@@ -222,7 +227,8 @@
         io.socket.request({
             url: url,
             params: data,
-            method: verb
+            method: verb,
+            headers: options.headers
         }, function serverResponded(body, jwr) {
             var isSuccess = jwr.statusCode >= 200 && jwr.statusCode < 300 || jwr.statusCode === 304;
 


### PR DESCRIPTION
Pass headers options to `socket.io` request.
This is a slight modified version of https://github.com/metidia/backbone-to-sails/commit/b8d215ddc21594922854b39f47959cd0b5760d98, which I guess was meant for 0.11
